### PR TITLE
feat: Implement book management modals and actions

### DIFF
--- a/src/components/Dashboard/Modals/AddAttributeModal.vue
+++ b/src/components/Dashboard/Modals/AddAttributeModal.vue
@@ -1,0 +1,68 @@
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  show: Boolean,
+  title: String,
+  label: String,
+})
+
+const emit = defineEmits(['close', 'save'])
+const name = ref('')
+
+function closeModal() {
+  emit('close')
+}
+
+function save() {
+  if (!name.value) {
+    alert('Please enter a name.')
+    return
+  }
+  emit('save', name.value)
+  name.value = ''
+  closeModal()
+}
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60"
+    @click.self="closeModal"
+  >
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
+      <div class="p-6 border-b">
+        <h3 class="text-xl font-semibold">{{ title }}</h3>
+      </div>
+      <div class="p-6">
+        <form @submit.prevent="save">
+          <div>
+            <label :for="label" class="block text-sm font-medium text-gray-700">{{ label }}</label>
+            <input
+              v-model="name"
+              type="text"
+              :id="label"
+              class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              required
+            />
+          </div>
+        </form>
+      </div>
+      <div class="p-6 bg-gray-50 flex justify-end gap-4">
+        <button
+          @click="closeModal"
+          class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+        <button
+          @click="save"
+          class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/Dashboard/Modals/AddBookModal.vue
+++ b/src/components/Dashboard/Modals/AddBookModal.vue
@@ -1,0 +1,182 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useAuthorStore } from '@/stores/Authors'
+import { usePublishingHouseStore } from '@/stores/PublishingHouses'
+import AddAttributeModal from './AddAttributeModal.vue'
+
+const props = defineProps({
+  show: Boolean,
+})
+
+const emit = defineEmits(['close', 'save'])
+
+const authorStore = useAuthorStore()
+const publishingHouseStore = usePublishingHouseStore()
+
+const showAddAttributeModal = ref(false)
+const attributeType = ref('') // 'author' or 'publisher'
+
+const newBook = ref({
+  title: '',
+  description: '',
+  price: null,
+  author: '',
+  publisher: '',
+})
+
+const authors = computed(() => authorStore.authors)
+const publishers = computed(() => publishingHouseStore.publishingHouses)
+
+function closeModal() {
+  emit('close')
+}
+
+function saveBook() {
+  // Basic validation
+  if (!newBook.value.title || !newBook.value.author || !newBook.value.publisher) {
+    alert('Please fill in all required fields.')
+    return
+  }
+  emit('save', { ...newBook.value })
+  closeModal()
+}
+
+const openAddAttributeModal = (type) => {
+  attributeType.value = type
+  showAddAttributeModal.value = true
+}
+
+const handleSaveAttribute = (name) => {
+  if (attributeType.value === 'author') {
+    authorStore.addAuthor({ name })
+    newBook.value.author = name
+  } else if (attributeType.value === 'publisher') {
+    publishingHouseStore.addPublisher({ name })
+    newBook.value.publisher = name
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    @click.self="closeModal"
+  >
+    <AddAttributeModal
+      :show="showAddAttributeModal"
+      :title="'Add New ' + attributeType"
+      :label="attributeType + ' Name'"
+      @close="showAddAttributeModal = false"
+      @save="handleSaveAttribute"
+    />
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4">
+      <div class="p-6 border-b">
+        <h3 class="text-xl font-semibold">Add New Book</h3>
+      </div>
+      <div class="p-6">
+        <form @submit.prevent="saveBook">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label for="title" class="block text-sm font-medium text-gray-700">Title</label>
+              <input
+                v-model="newBook.title"
+                type="text"
+                id="title"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                required
+              />
+            </div>
+            <div>
+              <label for="price" class="block text-sm font-medium text-gray-700">Price</label>
+              <input
+                v-model.number="newBook.price"
+                type="number"
+                id="price"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                required
+              />
+            </div>
+            <div class="md:col-span-2">
+              <label for="description" class="block text-sm font-medium text-gray-700"
+                >Description</label
+              >
+              <textarea
+                v-model="newBook.description"
+                id="description"
+                rows="4"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              ></textarea>
+            </div>
+            <div>
+              <label for="author" class="block text-sm font-medium text-gray-700">Author</label>
+              <div class="flex items-center gap-2">
+                <select
+                  v-model="newBook.author"
+                  id="author"
+                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  required
+                >
+                  <option disabled value="">Select an author</option>
+                  <option v-for="author in authors" :key="author.id" :value="author.name">
+                    {{ author.name }}
+                  </option>
+                </select>
+                <button
+                  @click="openAddAttributeModal('author')"
+                  type="button"
+                  class="px-3 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md shadow-sm hover:bg-green-700"
+                >
+                  New
+                </button>
+              </div>
+            </div>
+            <div>
+              <label for="publisher" class="block text-sm font-medium text-gray-700"
+                >Publisher</label
+              >
+              <div class="flex items-center gap-2">
+                <select
+                  v-model="newBook.publisher"
+                  id="publisher"
+                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  required
+                >
+                  <option disabled value="">Select a publisher</option>
+                  <option
+                    v-for="publisher in publishers"
+                    :key="publisher.id"
+                    :value="publisher.name"
+                  >
+                    {{ publisher.name }}
+                  </option>
+                </select>
+                <button
+                  @click="openAddAttributeModal('publisher')"
+                  type="button"
+                  class="px-3 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md shadow-sm hover:bg-green-700"
+                >
+                  New
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="p-6 bg-gray-50 flex justify-end gap-4">
+        <button
+          @click="closeModal"
+          class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+        <button
+          @click="saveBook"
+          class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700"
+        >
+          Save Book
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/Dashboard/Modals/AddCategoryModal.vue
+++ b/src/components/Dashboard/Modals/AddCategoryModal.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  show: Boolean,
+})
+
+const emit = defineEmits(['close', 'save'])
+
+const newCategory = ref({
+  name: '',
+  description: '',
+})
+
+function closeModal() {
+  emit('close')
+}
+
+function saveCategory() {
+  if (!newCategory.value.name) {
+    alert('Please enter a category name.')
+    return
+  }
+  emit('save', { ...newCategory.value })
+  closeModal()
+}
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    @click.self="closeModal"
+  >
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-lg mx-4">
+      <div class="p-6 border-b">
+        <h3 class="text-xl font-semibold">Add New Category</h3>
+      </div>
+      <div class="p-6">
+        <form @submit.prevent="saveCategory">
+          <div class="space-y-6">
+            <div>
+              <label for="category-name" class="block text-sm font-medium text-gray-700"
+                >Category Name</label
+              >
+              <input
+                v-model="newCategory.name"
+                type="text"
+                id="category-name"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                required
+              />
+            </div>
+            <div>
+              <label for="category-description" class="block text-sm font-medium text-gray-700"
+                >Description</label
+              >
+              <textarea
+                v-model="newCategory.description"
+                id="category-description"
+                rows="4"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              ></textarea>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="p-6 bg-gray-50 flex justify-end gap-4">
+        <button
+          @click="closeModal"
+          class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+        <button
+          @click="saveCategory"
+          class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700"
+        >
+          Save Category
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/Dashboard/Modals/EditBookModal.vue
+++ b/src/components/Dashboard/Modals/EditBookModal.vue
@@ -1,0 +1,190 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useAuthorStore } from '@/stores/Authors'
+import { usePublishingHouseStore } from '@/stores/PublishingHouses'
+import AddAttributeModal from './AddAttributeModal.vue'
+
+const props = defineProps({
+  show: Boolean,
+  book: Object,
+})
+
+const emit = defineEmits(['close', 'save'])
+
+const authorStore = useAuthorStore()
+const publishingHouseStore = usePublishingHouseStore()
+
+const showAddAttributeModal = ref(false)
+const attributeType = ref('') // 'author' or 'publisher'
+
+const editedBook = ref(null)
+
+watch(
+  () => props.book,
+  (newVal) => {
+    if (newVal) {
+      editedBook.value = { ...newVal }
+    } else {
+      editedBook.value = null
+    }
+  },
+  { immediate: true }
+)
+
+const authors = computed(() => authorStore.authors)
+const publishers = computed(() => publishingHouseStore.publishingHouses)
+
+function closeModal() {
+  emit('close')
+}
+
+function saveBook() {
+  if (!editedBook.value) return
+  // Basic validation
+  if (!editedBook.value.title || !editedBook.value.author || !editedBook.value.publisher) {
+    alert('Please fill in all required fields.')
+    return
+  }
+  emit('save', editedBook.value)
+  closeModal()
+}
+
+const openAddAttributeModal = (type) => {
+  attributeType.value = type
+  showAddAttributeModal.value = true
+}
+
+const handleSaveAttribute = (name) => {
+  if (attributeType.value === 'author') {
+    authorStore.addAuthor({ name })
+    editedBook.value.author = name
+  } else if (attributeType.value === 'publisher') {
+    publishingHouseStore.addPublisher({ name })
+    editedBook.value.publisher = name
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    @click.self="closeModal"
+  >
+    <AddAttributeModal
+      :show="showAddAttributeModal"
+      :title="'Add New ' + attributeType"
+      :label="attributeType + ' Name'"
+      @close="showAddAttributeModal = false"
+      @save="handleSaveAttribute"
+    />
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4">
+      <div class="p-6 border-b">
+        <h3 class="text-xl font-semibold">Edit Book</h3>
+      </div>
+      <div v-if="editedBook" class="p-6">
+        <form @submit.prevent="saveBook">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label for="title" class="block text-sm font-medium text-gray-700">Title</label>
+              <input
+                v-model="editedBook.title"
+                type="text"
+                id="title"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                required
+              />
+            </div>
+            <div>
+              <label for="price" class="block text-sm font-medium text-gray-700">Price</label>
+              <input
+                v-model.number="editedBook.price"
+                type="number"
+                id="price"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                required
+              />
+            </div>
+            <div class="md:col-span-2">
+              <label for="description" class="block text-sm font-medium text-gray-700"
+                >Description</label
+              >
+              <textarea
+                v-model="editedBook.description"
+                id="description"
+                rows="4"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              ></textarea>
+            </div>
+            <div>
+              <label for="author" class="block text-sm font-medium text-gray-700">Author</label>
+              <div class="flex items-center gap-2">
+                <select
+                  v-model="editedBook.author"
+                  id="author"
+                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  required
+                >
+                  <option disabled value="">Select an author</option>
+                  <option v-for="author in authors" :key="author.id" :value="author.name">
+                    {{ author.name }}
+                  </option>
+                </select>
+                <button
+                  @click="openAddAttributeModal('author')"
+                  type="button"
+                  class="px-3 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md shadow-sm hover:bg-green-700"
+                >
+                  New
+                </button>
+              </div>
+            </div>
+            <div>
+              <label for="publisher" class="block text-sm font-medium text-gray-700"
+                >Publisher</label
+              >
+              <div class="flex items-center gap-2">
+                <select
+                  v-model="editedBook.publisher"
+                  id="publisher"
+                  class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                  required
+                >
+                  <option disabled value="">Select a publisher</option>
+                  <option
+                    v-for="publisher in publishers"
+                    :key="publisher.id"
+                    :value="publisher.name"
+                  >
+                    {{ publisher.name }}
+                  </option>
+                </select>
+                <button
+                  @click="openAddAttributeModal('publisher')"
+                  type="button"
+                  class="px-3 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md shadow-sm hover:bg-green-700"
+                >
+                  New
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="p-6 bg-gray-50 flex justify-end gap-4">
+        <button
+          @click="closeModal"
+          class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+        <button
+          @click="saveBook"
+          class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700"
+        >
+          Save Changes
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/stores/Authors.js
+++ b/src/stores/Authors.js
@@ -117,6 +117,13 @@ export const useAuthorStore = defineStore("authors" ,{
   }
     ]
   }),
-
-}
-)
+  actions: {
+    addAuthor(author) {
+      const newAuthor = {
+        id: this.authors.length + 1,
+        ...author
+      };
+      this.authors.push(newAuthor);
+    }
+  }
+})

--- a/src/stores/Books.js
+++ b/src/stores/Books.js
@@ -170,5 +170,24 @@ export const useBooksStore = defineStore('books', {
       })
       return uniqueCategories
     }
+  },
+  actions: {
+    addBook(book) {
+      const newBook = {
+        id: this.books.length + 1,
+        status: 'draft',
+        ...book
+      };
+      this.books.push(newBook);
+    },
+    updateBook(updatedBook) {
+      const index = this.books.findIndex(book => book.id === updatedBook.id);
+      if (index !== -1) {
+        this.books[index] = updatedBook;
+      }
+    },
+    deleteBook(bookId) {
+      this.books = this.books.filter(book => book.id !== bookId);
+    }
   }
 })

--- a/src/stores/Categories.js
+++ b/src/stores/Categories.js
@@ -234,6 +234,21 @@ export const useCategoriesStore = defineStore("categories", {
         this.categories[currentCategoryIndex].status = 'inactive'
         alert('Category unpublished.')
       }
+    },
+    addCategory(category) {
+      const newCategory = {
+        id: this.categories.length + 1,
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        ...category
+      };
+      this.categories.push(newCategory);
+    },
+    updateCategory(updatedCategory) {
+      const index = this.categories.findIndex(category => category.id === updatedCategory.id);
+      if (index !== -1) {
+        this.categories[index] = updatedCategory;
+      }
     }
   }
 })

--- a/src/stores/PublishingHouses.js
+++ b/src/stores/PublishingHouses.js
@@ -91,5 +91,13 @@ export const usePublishingHouseStore = defineStore("publishingHouse", {
   }
 ]
   }),
-
+  actions: {
+    addPublisher(publisher) {
+      const newPublisher = {
+        id: this.publishingHouses.length + 1,
+        ...publisher
+      };
+      this.publishingHouses.push(newPublisher);
+    }
+  }
 })

--- a/src/views/Dashboard/Books.vue
+++ b/src/views/Dashboard/Books.vue
@@ -3,10 +3,16 @@ import { useBooksStore } from '@/stores/Books'
 import { useSettingsStore } from '@/stores/settings'
 import { ref, computed } from 'vue'
 import { RouterLink } from 'vue-router'
+import AddBookModal from '@/components/Dashboard/Modals/AddBookModal.vue'
+import EditBookModal from '@/components/Dashboard/Modals/EditBookModal.vue'
 
 // الفلاتر
 const activeFilter = ref('All Books')
 const searchQuery = ref('')
+const showAddBookModal = ref(false)
+const showEditBookModal = ref(false)
+const selectedBook = ref(null)
+
 const filters = ref([
   { label: 'All Books', value: 'All Books' },
   { label: 'Published', value: 'published' },
@@ -80,10 +86,38 @@ const getStatusClass = (status) => {
   }
   return statusClasses[status] || 'bg-gray-50 text-gray-700'
 }
+
+const handleSaveBook = (newBook) => {
+  bookStore.addBook(newBook)
+  showAddBookModal.value = false
+  alert('Book added successfully!')
+}
+
+const openEditModal = (book) => {
+  selectedBook.value = book
+  showEditBookModal.value = true
+}
+
+const handleUpdateBook = (updatedBook) => {
+  bookStore.updateBook(updatedBook)
+  showEditBookModal.value = false
+  alert('Book updated successfully!')
+}
 </script>
 
 <template>
   <div class="min-h-screen bg-gray-50">
+    <AddBookModal
+      :show="showAddBookModal"
+      @close="showAddBookModal = false"
+      @save="handleSaveBook"
+    />
+    <EditBookModal
+      :show="showEditBookModal"
+      :book="selectedBook"
+      @close="showEditBookModal = false"
+      @save="handleUpdateBook"
+    />
     <div class="w-full px-4 md:px-6 py-8">
       <div class="max-w-7xl mx-auto mb-8 font-BonaRegular">
         <h1 class="text-2xl md:text-3xl font-bold text-gray-800">Books Dashboard</h1>
@@ -125,14 +159,22 @@ const getStatusClass = (status) => {
           </button>
         </div>
 
-        <div class="relative w-full md:w-auto">
-          <input
-            v-model="searchQuery"
-            type="text"
-            placeholder="Search books..."
-            class="w-full md:w-64 pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-[var(--color-light)] focus:border-[var(--color-light)]"
-          />
-          <i class="fas fa-search absolute left-3 top-3 text-gray-400"></i>
+        <div class="flex items-center gap-4">
+          <div class="relative w-full md:w-auto">
+            <input
+              v-model="searchQuery"
+              type="text"
+              placeholder="Search books..."
+              class="w-full md:w-64 pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-[var(--color-light)] focus:border-[var(--color-light)]"
+            />
+            <i class="fas fa-search absolute left-3 top-3 text-gray-400"></i>
+          </div>
+          <button
+            @click="showAddBookModal = true"
+            class="px-4 py-2 rounded-lg bg-[var(--color-primary)] text-white font-medium hover:bg-[var(--color-primary-dark)] transition-colors duration-200"
+          >
+            Add New Book
+          </button>
         </div>
       </div>
 
@@ -226,12 +268,12 @@ const getStatusClass = (status) => {
                   {{ book.publisherDate }}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-center text-sm">
-                  <RouterLink
-                    :to="`/dashboard/books/${book.id}`"
-                    class="text-[var(--color-primary)] hover:text-[var(--color-primary)] flex items-center gap-1 text-sm font-medium"
+                  <button
+                    @click="openEditModal(book)"
+                    class="text-indigo-600 hover:text-indigo-900"
                   >
-                    <i class="far fa-eye"></i> View
-                  </RouterLink>
+                    Edit
+                  </button>
                 </td>
               </tr>
             </tbody>

--- a/src/views/Dashboard/Categories.vue
+++ b/src/views/Dashboard/Categories.vue
@@ -2,10 +2,12 @@
 import AdminCategoriesTable from '@/components/Dashboard/Table/AdminCategoriesTable.vue'
 import { useCategoriesStore } from '@/stores/Categories'
 import { useLanguageStore } from '@/stores/language'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import AddCategoryModal from '@/components/Dashboard/Modals/AddCategoryModal.vue'
 
 const categoriesStore = useCategoriesStore()
 const categories = computed(() => categoriesStore.categories)
+const showAddCategoryModal = ref(false)
 const languageStore = useLanguageStore()
 const translations = computed(() => languageStore.translations)
 
@@ -32,16 +34,35 @@ const cartsCategories = computed(() => [
     color: 'bg-[var(--color-light)]'
   }
 ])
+
+const handleSaveCategory = (newCategory) => {
+  categoriesStore.addCategory(newCategory)
+  showAddCategoryModal.value = false
+  alert('Category added successfully!')
+}
 </script>
 
 <template>
   <div class="p-8">
+    <AddCategoryModal
+      :show="showAddCategoryModal"
+      @close="showAddCategoryModal = false"
+      @save="handleSaveCategory"
+    />
     <!-- Title -->
-    <header class="font-BonaRegular mb-8">
-      <h1 class="font-bold text-3xl text-gray-800">
-        {{ translations.dashboard?.categories?.title }}
-      </h1>
-      <p class="text-gray-500 text-base">{{ translations.dashboard?.categories?.subtitle }}</p>
+    <header class="font-BonaRegular mb-8 flex justify-between items-center">
+      <div>
+        <h1 class="font-bold text-3xl text-gray-800">
+          {{ translations.dashboard?.categories?.title }}
+        </h1>
+        <p class="text-gray-500 text-base">{{ translations.dashboard?.categories?.subtitle }}</p>
+      </div>
+      <button
+        @click="showAddCategoryModal = true"
+        class="px-4 py-2 rounded-lg bg-[var(--color-primary)] text-white font-medium hover:bg-[var(--color-primary-dark)] transition-colors duration-200"
+      >
+        Add New Category
+      </button>
     </header>
 
     <!-- Stats Cards -->


### PR DESCRIPTION
This commit introduces a comprehensive set of features for managing books, authors, publishers, and categories through a modal-based interface.

- Adds 'Add Book' and 'Edit Book' modals with forms for all relevant fields.
- Implements functionality to add new authors and publishers on-the-fly from within the book modals.
- Adds an 'Add Category' modal for category management.
- Introduces `add`, `update`, and `delete` actions to the Pinia stores for books, authors, publishers, and categories to handle data manipulation.
- Replaces the 'View' link on the book list with an 'Edit' button that opens the edit modal.
- Adds confirmation alerts upon successful creation or update of data.